### PR TITLE
isAsset bugfix

### DIFF
--- a/lib/src/mesh.dart
+++ b/lib/src/mesh.dart
@@ -206,7 +206,7 @@ Future<List<Mesh>> _buildMesh(
 
     // load texture image from assets.
     final Material? material = (materials != null) ? materials[elementMaterials[index]] : null;
-    final MapEntry<String, Image>? imageEntry = await loadTexture(material, basePath);
+    final MapEntry<String, Image>? imageEntry = await loadTexture(material, basePath, isAsset: isAsset);
 
     // fix zero texture area
     if (imageEntry != null) {


### PR DESCRIPTION
`isAsset` parameter was not passed on to `loadTexture`. This fixes loading textures from local storages