### PR TITLE
Check mounted before setState

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -46,7 +46,9 @@ class _CubeState extends State<Cube> {
   void initState() {
     super.initState();
     scene = Scene(
-      onUpdate: () => setState(() {}),
+      onUpdate: () {
+        if (mounted) setState(() {});
+      },
       onObjectCreated: widget.onObjectCreated,
     );
     // prevent setState() or markNeedsBuild called during build


### PR DESCRIPTION
I was getting exceptions here if I would leave the page before the model was loaded. This mounted check seem to fix that.